### PR TITLE
Add handling of the case when type filter is -1

### DIFF
--- a/src/ehp.cpp
+++ b/src/ehp.cpp
@@ -1423,7 +1423,7 @@ bool lsda_type_table_entry_t<ptrsize>::parse(
 	const auto tt_encoding_sans_indirect = tt_encoding&(~DW_EH_PE_indirect);
 	const auto tt_encoding_sans_indir_sans_pcrel = static_cast<uint8_t>(tt_encoding_sans_indirect & (~DW_EH_PE_pcrel));
 	const auto has_pcrel = (tt_encoding & DW_EH_PE_pcrel) == DW_EH_PE_pcrel;
-    tt_encoding_size = get_tt_encoding_size(p_tt_encoding);
+	tt_encoding_size = get_tt_encoding_size(p_tt_encoding);
 
 	const auto orig_act_pos=uint64_t(tt_pos+(-static_cast<int64_t>(index)*tt_encoding_size));
 	auto act_pos=uint64_t(tt_pos+(-static_cast<int64_t>(index)*tt_encoding_size));
@@ -1703,39 +1703,39 @@ bool lsda_t<ptrsize>::parse_lsda(
 					if(parse_and_insert_tt_entry(type_filter))
 						return true;
 				}
-                else if(type_filter==-1)
+				else if(type_filter==-1)
 				{
-                    // When the type filter is -1, it means that the catch
-                    // handler can handle exceptions of any type.
-                    // It typically indicates a Dynamic Exception Specification
-                    // (DES) is in play. DES was a feature in C++ that allowed
-                    // a function to declare the types of exceptions it could
-                    // potentially throw.
-                    //
-                    // Although this feature is deprecated in C++11, for
-                    // binaries built with older versions of C++, we handle
-                    // such case here by parsing all the entries in the type
-                    // table.
+					// When the type filter is -1, it means that the catch
+					// handler can handle exceptions of any type.
+					// It typically indicates a Dynamic Exception Specification
+					// (DES) is in play. DES was a feature in C++ that allowed
+					// a function to declare the types of exceptions it could
+					// potentially throw.
+					//
+					// Although this feature is deprecated in C++11, for
+					// binaries built with older versions of C++, we handle
+					// such case here by parsing all the entries in the type
+					// table.
 
-                    // First of all, make sure that there is only one action
-                    // table entry.
-                    size_t at_entry_count = cs_tab_entry.getActionTableInternal().size();
-                    if (at_entry_count != 1) {
-                        throw_assert(0);
-                    }
+					// First of all, make sure that there is only one action
+					// table entry.
+					size_t at_entry_count = cs_tab_entry.getActionTableInternal().size();
+					if (at_entry_count != 1) {
+						throw_assert(0);
+					}
 
-                    // The number of type-table entries is calculated by
-                    // dividing the type-table size by the type-table encoding
-                    // size.
-                    uint64_t tt_size = type_table_addr - cs_table_end_addr - 2;
-                    uint64_t tt_encoding_size = lsda_type_table_entry_t<ptrsize>::get_tt_encoding_size(type_table_encoding);
-                    uint64_t tt_entry_count = tt_size / tt_encoding_size;
+					// The number of type-table entries is calculated by
+					// dividing the type-table size by the type-table encoding
+					// size.
+					uint64_t tt_size = type_table_addr - cs_table_end_addr - 2;
+					uint64_t tt_encoding_size = lsda_type_table_entry_t<ptrsize>::get_tt_encoding_size(type_table_encoding);
+					uint64_t tt_entry_count = tt_size / tt_encoding_size;
 
-                    uint64_t idx = 1;
-                    while (idx <= tt_entry_count) {
-                        if(parse_and_insert_tt_entry(idx++))
-                            return true;
-                    }
+					uint64_t idx = 1;
+					while (idx <= tt_entry_count) {
+						if(parse_and_insert_tt_entry(idx++))
+							return true;
+					}
 				}
 				else 
 					throw_assert(0);

--- a/src/ehp_priv.hpp
+++ b/src/ehp_priv.hpp
@@ -262,7 +262,8 @@ class lsda_type_table_entry_t: public LSDATypeTableEntry_t, private eh_frame_uti
 		);
 
 	void print() const;
-	
+
+    static uint64_t get_tt_encoding_size(uint64_t tt_encoding);
 };
 
 template <int ptrsize>

--- a/src/ehp_priv.hpp
+++ b/src/ehp_priv.hpp
@@ -263,7 +263,7 @@ class lsda_type_table_entry_t: public LSDATypeTableEntry_t, private eh_frame_uti
 
 	void print() const;
 
-    static uint64_t get_tt_encoding_size(uint64_t tt_encoding);
+	static uint64_t get_tt_encoding_size(uint64_t tt_encoding);
 };
 
 template <int ptrsize>

--- a/test/SConscript
+++ b/test/SConscript
@@ -37,6 +37,12 @@ myenv=myenv.Clone(CPPPATH=Split(cpppath))
 myenv.Append(CXXFLAGS = " -std=c++11 -Wall -Werror -fmax-errors=1 -g ")
 
 lib=myenv.Program("test.exe",  Split(files), LIBPATH=Split(LIBPATH), LIBS=Split(LIBS))
-Default(lib)
 
-Return('lib')
+myenv=env.Clone(CPPPATH=Split(cpppath))
+myenv.Append(CXXFLAGS = " -std=c++11 -Wall -Wno-deprecated -Wno-reorder -g ")
+
+lib2=myenv.Program("test_des.exe",  Split("test_des.cpp"), LIBPATH=Split(LIBPATH), LIBS=Split(LIBS))
+
+Default([lib, lib2])
+
+Return(['lib', 'lib2'])

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -25,8 +25,8 @@ using namespace EHP;
 
 void usage(int argc, char* argv[])
 {
-    cout<<"Usage: "<<argv[0]<<" <program to print eh info> "
-        <<"[total-number-of-LSDA total-number-of-TypeTableEntries]\n";
+	cout<<"Usage: "<<argv[0]<<" <program to print eh info> "
+		<<"[total-number-of-LSDA total-number-of-TypeTableEntries]\n";
 	exit(1);
 }
 
@@ -56,7 +56,7 @@ void print_lps(const EHFrameParser_t* ehp)
 int main(int argc, char* argv[])
 {
 
-    if(argc!=2 && argc!=4)
+	if(argc!=2 && argc!=4)
 	{
 		usage(argc,argv);
 	}
@@ -69,44 +69,43 @@ int main(int argc, char* argv[])
 
 		print_lps(ehp.get());
 
+		if (argc == 4) {
+			int expected_lsda_count = atoi(argv[2]);
+			int expected_tt_entry_count = atoi(argv[3]);
 
-        if (argc == 4) {
-            int expected_lsda_count = atoi(argv[2]);
-            int expected_tt_entry_count = atoi(argv[3]);
+			int lsda_count = 0;
+			int tt_entry_count = 0;
+			for (const auto *fde : *(ehp->getFDEs()))
+			{
+				auto * lsda = fde->getLSDA();
+				if (lsda && fde->getLSDAAddress() != 0)
+				{
+					lsda_count++;
+					tt_entry_count += lsda->getTypeTable()->size();
+				}
+			}
 
-            int lsda_count = 0;
-            int tt_entry_count = 0;
-            for (const auto *fde : *(ehp->getFDEs()))
-            {
-                auto * lsda = fde->getLSDA();
-                if (lsda && fde->getLSDAAddress() != 0)
-                {
-                    lsda_count++;
-                    tt_entry_count += lsda->getTypeTable()->size();
-                }
-            }
-
-            if (expected_lsda_count == lsda_count
-                    && expected_tt_entry_count == tt_entry_count)
-            {
-                cout << "SUCCESS!\n"
-                     << "  count(LSDA)=" << lsda_count << endl
-                     << "  count(TypeTableEntries)=" << tt_entry_count << endl;
-            }
-            else
-            {
-                if (expected_lsda_count != lsda_count) {
-                    cout << "FAILED: count(LSDA)="
-                         << lsda_count << " != " << expected_lsda_count << endl;
-                }
-                if (expected_tt_entry_count != tt_entry_count) {
-                    cout << "FAILED: count(TypeTableEntries)="
-                         << tt_entry_count << " != " << expected_tt_entry_count
-                         << endl;
-                }
-                return -1;
-            }
-        }
+			if (expected_lsda_count == lsda_count
+				&& expected_tt_entry_count == tt_entry_count)
+			{
+				cout << "SUCCESS!\n"
+					 << "  count(LSDA)=" << lsda_count << endl
+					 << "  count(TypeTableEntries)=" << tt_entry_count << endl;
+			}
+			else
+			{
+				if (expected_lsda_count != lsda_count) {
+					cout << "FAILED: count(LSDA)="
+				 		 << lsda_count << " != " << expected_lsda_count << endl;
+				}
+				if (expected_tt_entry_count != tt_entry_count) {
+					cout << "FAILED: count(TypeTableEntries)="
+	 					 << tt_entry_count << " != " << expected_tt_entry_count
+						 << endl;
+				}
+				return -1;
+			}
+		}
 	}
 	catch(const exception& e )
 	{

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -25,7 +25,8 @@ using namespace EHP;
 
 void usage(int argc, char* argv[])
 {
-	cout<<"Usage: "<<argv[0]<<" <program to print eh info>"<<endl;
+    cout<<"Usage: "<<argv[0]<<" <program to print eh info> "
+        <<"[total-number-of-LSDA total-number-of-TypeTableEntries]\n";
 	exit(1);
 }
 
@@ -55,7 +56,7 @@ void print_lps(const EHFrameParser_t* ehp)
 int main(int argc, char* argv[])
 {
 
-	if(argc!=2)
+    if(argc!=2 && argc!=4)
 	{
 		usage(argc,argv);
 	}
@@ -67,6 +68,45 @@ int main(int argc, char* argv[])
 
 
 		print_lps(ehp.get());
+
+
+        if (argc == 4) {
+            int expected_lsda_count = atoi(argv[2]);
+            int expected_tt_entry_count = atoi(argv[3]);
+
+            int lsda_count = 0;
+            int tt_entry_count = 0;
+            for (const auto *fde : *(ehp->getFDEs()))
+            {
+                auto * lsda = fde->getLSDA();
+                if (lsda && fde->getLSDAAddress() != 0)
+                {
+                    lsda_count++;
+                    tt_entry_count += lsda->getTypeTable()->size();
+                }
+            }
+
+            if (expected_lsda_count == lsda_count
+                    && expected_tt_entry_count == tt_entry_count)
+            {
+                cout << "SUCCESS!\n"
+                     << "  count(LSDA)=" << lsda_count << endl
+                     << "  count(TypeTableEntries)=" << tt_entry_count << endl;
+            }
+            else
+            {
+                if (expected_lsda_count != lsda_count) {
+                    cout << "FAILED: count(LSDA)="
+                         << lsda_count << " != " << expected_lsda_count << endl;
+                }
+                if (expected_tt_entry_count != tt_entry_count) {
+                    cout << "FAILED: count(TypeTableEntries)="
+                         << tt_entry_count << " != " << expected_tt_entry_count
+                         << endl;
+                }
+                return -1;
+            }
+        }
 	}
 	catch(const exception& e )
 	{

--- a/test/test.sh
+++ b/test/test.sh
@@ -35,7 +35,7 @@ function main()
 	./test.exe /bin/ls || cleanup 
 	./test.exe /bin/bash || cleanup 
 
-    ./test.exe ./test_des.exe 2 6 || cleanup
+ 	./test.exe ./test_des.exe 2 6 || cleanup
 
 	echo "test passed"
 	exit 0

--- a/test/test.sh
+++ b/test/test.sh
@@ -35,6 +35,8 @@ function main()
 	./test.exe /bin/ls || cleanup 
 	./test.exe /bin/bash || cleanup 
 
+    ./test.exe ./test_des.exe 2 6 || cleanup
+
 	echo "test passed"
 	exit 0
 }

--- a/test/test_des.cpp
+++ b/test/test_des.cpp
@@ -1,0 +1,111 @@
+#include <exception>
+#include <iostream>
+
+class myException1 : public std::exception
+{
+public:
+    virtual const char* what() const throw()
+    {
+        return "threw myException1";
+    }
+};
+
+class myException2 : public std::exception
+{
+public:
+    virtual const char* what() const throw()
+    {
+        return "threw myException2";
+    }
+};
+
+class myException3 : public std::exception
+{
+public:
+    virtual const char* what() const throw()
+    {
+        return "threw myException3";
+    }
+};
+
+/*
+    void func(int bound) throw (myException)
+
+produces:
+
+    warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
+*/
+
+template <class T>
+class MyThing
+{
+public:
+    myException1 exception1;
+    myException2 exception2;
+    myException3 exception3;
+
+    MyThing(T arg, int bound) : bound(bound), arg(arg)
+    {
+    }
+
+    T& operator[](int index) throw(myException1, myException2, myException3)
+    {
+        // Throwing exception2 and exception3 here is non-sense,
+        // but this example is to demonstrate that libehp handles
+        // the Dynamic Exception Specification (DES) feature correctly.
+        if(index > bound)
+        {
+            throw exception1;
+        }
+        else if(index < bound && index > bound-7)
+        {
+            throw exception2;
+        }
+        else if(index < bound-7)
+        {
+            throw exception3;
+        }
+
+        std::cout << "no thrown\n";
+        return arg;
+    }
+
+private:
+    T arg;
+    int bound;
+};
+
+int main()
+{
+    MyThing<int> thing = MyThing<int>(5, 10);
+
+    try
+    {
+        thing[20];
+    }
+    catch(myException1& e)
+    {
+        std::cout << e.what() << std::endl;
+    }
+
+    try
+    {
+        thing[7];
+    }
+    catch(myException2& e)
+    {
+        std::cout << e.what() << std::endl;
+    }
+
+    try
+    {
+        thing[2];
+    }
+    catch(myException3& e)
+    {
+        std::cout << e.what() << std::endl;
+    }
+
+    return 0;
+}
+


### PR DESCRIPTION
Previously, libehp ignored the case when the type filter is -1 since it indicates that a dynamic exception specification (DES) is in play, and a DES is deprecated and is not common and even less likely to be needed for correct execution.

However, we observed that DDISASM failed to create `symbol_minus_symbol` rules for type-table entries for such LSDA action table because libehp fails to give proper information about the type-table entries.

A proper handling for such case was added in this PR.